### PR TITLE
docs: rewrite README with project overview, stack, and local dev steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,47 @@
-<samp>
-stack: next.js, tailwindcss, typescript, mdx, vercel
-</samp>
+# nexxel.dev
+
+my personal website — a minimal space for my thoughts, work, and experiments.
+
+built with next.js, typescript, and tailwindcss. deployed on vercel.
+
+## what's here
+
+- **blog** — writing about typescript, rust, developer tooling, and things i'm learning
+- **work** — current and past roles in software engineering
+- **projects** — open source tools like [create-t3-app](https://create.t3.gg) and random experiments
+- **links** — places you can find me
+
+## stack
+
+- next.js 16 (app router)
+- react 19
+- typescript
+- tailwindcss
+- mdx for content
+- shiki for syntax highlighting
+
+## running locally
+
+```bash
+# install dependencies
+bun install
+
+# start dev server
+bun run dev
+```
+
+## writing
+
+posts live in `/posts` as `.mdx` files. each post needs frontmatter:
+
+```yaml
+---
+title: "your title"
+description: "brief description"
+date: "march 11, 2026"
+---
+```
+
+## license
+
+[mit](./LICENSE)


### PR DESCRIPTION
This PR updates README.md to provide a clearer project overview, current stack, and practical local development steps. It replaces the prior condensed status with a richer introduction and new sections for easier onboarding and contribution.

What changed
- Replaced the short status snippet with a heading and description for nexxel.dev
- Added sections: what's here, stack, running locally, and writing
- Updated local development commands tobun install and bun run dev
- Documented content layout (posts) and frontmatter requirements for posts in /posts
- Overall improved readability and structure for new contributors and visitors

Why
- To reflect the current project structure and tooling
- To provide actionable guidance for running the site locally and contributing content

How to test locally (after merge)
- Clone the repository
- Run bun install
- Run bun run dev and open the local site to verify the updated README sections render as described

Files affected
- README.md (modified)